### PR TITLE
Set hive connector properties to allow additional table management options

### DIFF
--- a/charts/templates/presto/presto-configs.yaml
+++ b/charts/templates/presto/presto-configs.yaml
@@ -28,11 +28,11 @@ data:
     hive.metastore.uri=thrift://{{ template "kdp.metastore.fullname" . }}:{{ .Values.metastore.service.port }}
     hive.metastore.username={{ .Values.postgres.db.user }}
     hive.config.resources=/etc/hadoop/conf/core-site.xml
-    hive.allow-drop-table=true
-    hive.allow-rename-table=true
-    hive.allow-drop-column=true
-    hive.allow-rename-column=true
-    hive.allow-add-column=true
+    hive.allow-drop-table={{ .Values.metastore.allowDropTable }}
+    hive.allow-rename-table={{ .Values.metastore.allowDropTable }}
+    hive.allow-drop-column={{ .Values.metastore.allowDropTable }}
+    hive.allow-rename-column={{ .Values.metastore.allowDropTable }}
+    hive.allow-add-column={{ .Values.metastore.allowDropTable }}
 {{- if and .Values.global.objectStore.accessKey .Values.global.objectStore.accessSecret }}
     hive.s3.aws-access-key={{ .Values.global.objectStore.accessKey }}
     hive.s3.aws-secret-key={{ .Values.global.objectStore.accessSecret }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -40,6 +40,7 @@ presto:
       alb.ingress.kubernetes.io/healthcheck-path: /v1/cluster
 
 metastore:
+  allowDropTable: false
   service:
     type: ClusterIP
     port: 9083
@@ -119,3 +120,4 @@ global:
   environment: sandbox
   objectStore:
     bucketName: kdp-cloud-storage
+

--- a/terraform/variables/dev.tfvars
+++ b/terraform/variables/dev.tfvars
@@ -1,2 +1,5 @@
 is_internal = true
+
 os_role_arn = "arn:aws:iam::073132350570:role/jenkins_role"
+
+allow_drop_table = true

--- a/terraform/variables/prod.tfvars
+++ b/terraform/variables/prod.tfvars
@@ -1,3 +1,7 @@
 is_internal = true
+
 os_role_arn = "arn:aws:iam::374013108165:role/jenkins_role"
+
 metastore_instance_class = "db.t3.medium"
+
+allow_drop_table = false

--- a/terraform/variables/sandbox.tfvars
+++ b/terraform/variables/sandbox.tfvars
@@ -1,4 +1,9 @@
 is_internal = true
+
 state_bucket = "scos-sandbox-terraform-state"
+
 alm_role_arn = "arn:aws:iam::068920858268:role/admin_role"
+
 os_role_arn = "arn:aws:iam::068920858268:role/admin_role"
+
+allow_drop_table = true

--- a/terraform/variables/staging.tfvars
+++ b/terraform/variables/staging.tfvars
@@ -1,3 +1,7 @@
 is_internal = true
+
 os_role_arn = "arn:aws:iam::647770347641:role/jenkins_role"
+
 metastore_instance_class = "db.t3.medium"
+
+allow_drop_table = true


### PR DESCRIPTION
Allows for add column, rename column, drop column, rename table, and drop table from presto CLI