### PR TITLE
Increase metastore memory limit to 1.5G

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -59,10 +59,10 @@ metastore:
       pullPolicy: IfNotPresent
       resources:
         limits:
-          memory: 1Gi
+          memory: 1.5Gi
           cpu: 1
         requests:
-          memory: 1Gi
+          memory: 1.5Gi
           cpu: 1
     updateStrategy:
       type: RollingUpdate


### PR DESCRIPTION
Reducing maxHeapSize based on recommendation found in 
https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/ergonomics.html
```Maximum heap size of 1/4 of physical memory up to 1 GB```